### PR TITLE
Tensors should be moved to the cpu before serialization

### DIFF
--- a/R/write.R
+++ b/R/write.R
@@ -84,7 +84,7 @@ tensor_buffer <- function(x) {
 }
 
 tensor_buffer.torch_tensor <- function(x) {
-  torch::buffer_from_torch_tensor(x)
+  torch::buffer_from_torch_tensor(x$cpu())
 }
 
 tensor_meta <- function(x) {


### PR DESCRIPTION
Move tensor to cpu before getting it's buffer. Otherwise we are probably accessing wrong memory adresses.
Fix https://github.com/mlverse/luz/issues/131