### PR TITLE
Fix writing bfloat16 tensors

### DIFF
--- a/R/write.R
+++ b/R/write.R
@@ -118,6 +118,8 @@ size_from_meta <- function(meta) {
     4L
   } else if (meta$dtype == "F16") {
     2L
+  } else if (meta$dtype == "BF16") {
+    2L
   } else if (meta$dtype == "F64") {
     8L
   } else if (meta$dtype == "U8") {

--- a/tests/testthat/test-write.R
+++ b/tests/testthat/test-write.R
@@ -18,6 +18,7 @@ test_that("can write a safetensors file (torch)", {
 test_that("with different datatypes (torch)", {
   data_type <- c(
     "float16",
+    "bfloat16",
     "float",
     "float64",
     "bool",


### PR DESCRIPTION
## Summary

- Add BF16 (2 bytes) to `size_from_meta()` dtype dispatch table in `R/write.R`
- Add bfloat16 to the existing dtype round-trip test

## Problem

Writing bfloat16 tensors fails with `"Unsupported dtype BF16"`:

```r
x <- torch::torch_randn(4, 4)$to(dtype = torch::torch_bfloat16())
safe_save_file(list(x = x), "test.safetensors")
#> Error: Unsupported dtype "BF16"
```

Reading bfloat16 tensors already works — the torch backend's `torch_dtype_to_safe()` correctly maps `torch_bfloat16()` to `"BF16"`, and `torch_dtype_from_safe()` maps it back. Only the byte size calculation in `size_from_meta()` was missing the BF16 entry.

## Why it matters

Models like Gemma 3 (12B) and Qwen3-TTS ship weights in bfloat16. Loading them works, but re-saving (e.g., after quantization or fine-tuning) fails without this fix.

## Test plan

- [x] Existing dtype round-trip test expanded to include bfloat16
- [x] `R CMD check` passes