### PR TITLE
CRAN release v0.2.1

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,3 +8,4 @@
 ^pkgdown$
 ^cran-comments\.md$
 ^CRAN-SUBMISSION$
+^\.git$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,9 @@
 Package: safetensors
 Title: Safetensors File Format
-Version: 0.2.0.9000
+Version: 0.2.1
 Authors@R: c(
-    person("Daniel", "Falbel", , "daniel@posit.co", role = c("aut", "cre")),
+    person("Tomasz", "Kalinowski", , "tomasz@posit.co", role = c("ctb", "cre")),
+    person("Daniel", "Falbel", , "dfalbel@gmail.com", role = "aut"),
     person("Sebastian", "Fischer", , "seb.fischer@tutamail.com", role = "ctb"),
     person(family = "Posit", role = c("cph"))
     )
@@ -13,7 +14,7 @@ Description: A file format for storing tensors that is secure (doesn't allow for
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Suggests:
     testthat (>= 3.0.0),
     torch (>= 0.11.0)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# safetensors (development version)
+# safetensors 0.2.1
+
+* Changed maintainer to Tomasz Kalinowski.
 
 # safetensors 0.2.0
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -19,7 +19,7 @@ knitr::opts_chunk$set(
 [![R-CMD-check](https://github.com/mlverse/safetensors/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/mlverse/safetensors/actions/workflows/R-CMD-check.yaml)
 <!-- badges: end -->
 
-safetensors is a pure R implementation of the [safetensors](https://github.com/huggingface/safetensors) file format for both reading and writing.
+safetensors is a pure R implementation of the [safetensors](https://github.com/safetensors/safetensors) file format for both reading and writing.
 It currently supports the {torch} and {pjrt} frameworks.
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <!-- badges: end -->
 
 safetensors is a pure R implementation of the
-[safetensors](https://github.com/huggingface/safetensors) file format
+[safetensors](https://github.com/safetensors/safetensors) file format
 for both reading and writing. It currently supports the {torch} and
 {pjrt} frameworks.
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -2,4 +2,6 @@
 
 0 errors | 0 warnings | 1 note
 
-* This is a new release.
+* New maintainer:
+  Old maintainer: Daniel Falbel (daniel@posit.co)
+  New maintainer: Tomasz Kalinowski (tomasz@posit.co)


### PR DESCRIPTION
## Summary
- Bump version to 0.2.1 for CRAN release
- Change maintainer from Daniel Falbel to Tomasz Kalinowski
- Update RoxygenNote to 7.3.3
- Add `.git` to `.Rbuildignore`

## R CMD check results
0 errors | 0 warnings | 0 notes