### PR TITLE
Add float8 (F8_E4M3, F8_E5M2) dtype support for the torch framework

### DIFF
--- a/R/torch.R
+++ b/R/torch.R
@@ -19,6 +19,10 @@ torch_dtype_to_safe <- function(x) {
     return("I64")
   } else if (x == torch::torch_bfloat16()) {
     return("BF16")
+  } else if (x == torch::torch_float8_e4m3fn()) {
+    return("F8_E4M3")
+  } else if (x == torch::torch_float8_e5m2()) {
+    return("F8_E5M2")
   } else if (x == torch::torch_cfloat()) {
     return("C64")
   } else if (x == torch::torch_cdouble()) {
@@ -67,6 +71,8 @@ torch_dtype_from_safe <- function(x) {
     "I32" = "int32",
     "I64" = "int64",
     "BF16" = "bfloat16",
+    "F8_E4M3" = "float8_e4m3fn",
+    "F8_E5M2" = "float8_e5m2",
     cli::cli_abort("Unsupported dtype {.val {x}}")
   )
 }

--- a/R/write.R
+++ b/R/write.R
@@ -138,6 +138,10 @@ size_from_meta <- function(meta) {
     4L
   } else if (meta$dtype == "U64") {
     8L
+  } else if (meta$dtype == "F8_E4M3") {
+    1L
+  } else if (meta$dtype == "F8_E5M2") {
+    1L
   } else {
     cli::cli_abort("Unsupported dtype {.val {meta$dtype}}")
   }


### PR DESCRIPTION
Adds the two float8 dtypes from the safetensors spec to the torch
framework mapping, both reading and writing, plus their element sizes
in `size_from_meta()` so serialized headers get correct offsets.

Motivation: fp8-quantized model artifacts are increasingly common
(weights stored as float8_e4m3fn with a per-tensor scale). torch has
had `torch_float8_e4m3fn()`/`torch_float8_e5m2()` since 0.13, but
safetensors currently errors on files containing F8 tensors. We are
using this in diffuseR for locally quantized FLUX-family checkpoints.

Round-trip is covered by the same paths as the existing dtypes; happy
to add explicit F8 tests if you'd like them in the suite.