### PR TITLE
Use double offsets when reading and writing multi-GB files

### DIFF
--- a/R/safetensors.R
+++ b/R/safetensors.R
@@ -98,7 +98,7 @@ safetensors <- R6::R6Class(
         rawToChar(raw_json),
         simplifyVector = TRUE
       )
-      private$byte_buffer_begin <- 8L + metadata_size
+      private$byte_buffer_begin <- 8 + as.numeric(metadata_size)
     },
     #' @description
     #' Get the keys (tensor names) in the file
@@ -112,8 +112,11 @@ safetensors <- R6::R6Class(
     get_tensor = function(name) {
       meta <- self$metadata[[name]]
 
-      offset_start <- private$byte_buffer_begin + meta$data_offsets[1]
-      offset_length <- meta$data_offsets[2] - meta$data_offsets[1]
+      # Offsets in multi-GB files exceed .Machine$integer.max; JSON parses
+      # smaller values as integers, so sums must be computed as doubles
+      offsets <- as.numeric(meta$data_offsets)
+      offset_start <- private$byte_buffer_begin + offsets[1]
+      offset_length <- offsets[2] - offsets[1]
       self$max_offset <- max(self$max_offset, offset_start + offset_length)
 
       seek(self$con, offset_start)

--- a/R/write.R
+++ b/R/write.R
@@ -78,7 +78,9 @@ make_meta <- function(tensors, metadata) {
     meta_[["__metadata__"]] <- validate_metadata(metadata)
   }
 
-  pos <- 0L
+  # Offsets accumulate past .Machine$integer.max for multi-GB files;
+  # keep them as doubles (exactly representable well past 2^31)
+  pos <- 0
   for (nm in names(tensors)) {
     meta <- safe_tensor_meta(tensors[[nm]])
     meta$data_offsets <- c(pos, pos + size_from_meta(meta))
@@ -142,7 +144,9 @@ size_from_meta <- function(meta) {
     cli::cli_abort("Unsupported dtype {.val {meta$dtype}}")
   }
 
-  as.integer(numel * el_size)
+  # Doubles, not integers: tensor byte sizes and cumulative offsets can
+  # exceed .Machine$integer.max
+  numel * el_size
 }
 
 validate_metadata <- function(x) {


### PR DESCRIPTION
Byte offsets in safetensors headers routinely exceed .Machine$integer.max
for modern model shards (a single 4-10 GB safetensors file is standard
for LLM/diffusion checkpoints). Reading or writing such files currently
overflows the integer offset arithmetic.

This switches the offset bookkeeping to doubles (exact for file sizes up
to 2^53 bytes) on both the read and write paths. Verified against
multi-GB shards (up to 10 GB) from HuggingFace-distributed checkpoints
in diffuseR.